### PR TITLE
Fix memory safety issues and compilation error

### DIFF
--- a/include/id3v1/id3v1Types.h
+++ b/include/id3v1/id3v1Types.h
@@ -40,6 +40,8 @@ extern "C" {
  * @see https://en.wikipedia.org/wiki/List_of_ID3v1_Genres
  */
 typedef enum _Genre {
+    //! Unknown or invalid genre (used for error cases)
+    GENRE_UNKNOWN = -1,
     //! Blues Audio
     BLUES_GENRE,
     //! Classic Rock

--- a/include/id3v2/id3v2Frame.h
+++ b/include/id3v2/id3v2Frame.h
@@ -1,4 +1,4 @@
-x/**
+/**
  * @file id3v2Frame.h
  * @author Ewan Jones
  * @brief Function definitions for ID3v2 frame lifecycle, traversal, serialization, and content management

--- a/src/id3dev.c
+++ b/src/id3dev.c
@@ -34,6 +34,9 @@ static uint8_t id3PreferredStandard = ID3V2_TAG_VERSION_3;
  */
 ID3 *id3Create(Id3v2Tag *id3v2, Id3v1Tag *id3v1) {
     ID3 *metadata = malloc(sizeof(ID3));
+    if (metadata == NULL) {
+        return NULL;
+    }
 
     metadata->id3v2 = id3v2;
     metadata->id3v1 = id3v1;
@@ -1284,8 +1287,13 @@ char *id3ToJSON(const ID3 *metadata) {
     id3v2 = id3v2TagToJSON(metadata->id3v2);
 
     memCount += snprintf(NULL, 0, "{\"id3v1\":%s,\"id3v2\":%s}", id3v1, id3v2);
-    json = calloc(memCount, sizeof(char));
-    (void) snprintf(json, memCount, "{\"ID3v1\":%s,\"ID3v2\":%s}", id3v1, id3v2);
+    json = calloc(memCount + 1, sizeof(char));
+    if (json == NULL) {
+        free(id3v1);
+        free(id3v2);
+        return NULL;
+    }
+    (void) snprintf(json, memCount + 1, "{\"ID3v1\":%s,\"ID3v2\":%s}", id3v1, id3v2);
 
     free(id3v1);
     free(id3v2);

--- a/src/id3v1/id3v1.c
+++ b/src/id3v1/id3v1.c
@@ -631,7 +631,13 @@ char *id3v1GenreFromTable(Genre val) {
  * @return char* Newly allocated string containing the title.
  */
 char *id3v1ReadTitle(const Id3v1Tag *tag) {
-    char *r = calloc(sizeof(char), ID3V1_FIELD_SIZE + 1);
+    if (tag == NULL) {
+        return NULL;
+    }
+    char *r = calloc(ID3V1_FIELD_SIZE + 1, sizeof(char));
+    if (r == NULL) {
+        return NULL;
+    }
     memcpy(r, tag->title, ID3V1_FIELD_SIZE);
     return r;
 }
@@ -643,7 +649,13 @@ char *id3v1ReadTitle(const Id3v1Tag *tag) {
  * @return char* - Newly allocated string containing the artist.
  */
 char *id3v1ReadArtist(const Id3v1Tag *tag) {
-    char *r = calloc(sizeof(char), ID3V1_FIELD_SIZE + 1);
+    if (tag == NULL) {
+        return NULL;
+    }
+    char *r = calloc(ID3V1_FIELD_SIZE + 1, sizeof(char));
+    if (r == NULL) {
+        return NULL;
+    }
     memcpy(r, tag->artist, ID3V1_FIELD_SIZE);
     return r;
 }
@@ -655,7 +667,13 @@ char *id3v1ReadArtist(const Id3v1Tag *tag) {
  * @return char* - Newly allocated string containing the album.
  */
 char *id3v1ReadAlbum(const Id3v1Tag *tag) {
-    char *r = calloc(sizeof(char), ID3V1_FIELD_SIZE + 1);
+    if (tag == NULL) {
+        return NULL;
+    }
+    char *r = calloc(ID3V1_FIELD_SIZE + 1, sizeof(char));
+    if (r == NULL) {
+        return NULL;
+    }
     memcpy(r, tag->albumTitle, ID3V1_FIELD_SIZE);
     return r;
 }
@@ -667,6 +685,9 @@ char *id3v1ReadAlbum(const Id3v1Tag *tag) {
  * @return int - The year value from the tag.
  */
 int id3v1ReadYear(const Id3v1Tag *tag) {
+    if (tag == NULL) {
+        return 0;
+    }
     return tag->year;
 }
 
@@ -677,7 +698,13 @@ int id3v1ReadYear(const Id3v1Tag *tag) {
  * @return char* - Newly allocated string containing the comment.
  */
 char *id3v1ReadComment(const Id3v1Tag *tag) {
-    char *r = calloc(sizeof(char), ID3V1_FIELD_SIZE + 1);
+    if (tag == NULL) {
+        return NULL;
+    }
+    char *r = calloc(ID3V1_FIELD_SIZE + 1, sizeof(char));
+    if (r == NULL) {
+        return NULL;
+    }
     memcpy(r, tag->comment, ID3V1_FIELD_SIZE);
     return r;
 }
@@ -689,6 +716,9 @@ char *id3v1ReadComment(const Id3v1Tag *tag) {
  * @return Genre - The Genre value from the tag.
  */
 Genre id3v1ReadGenre(const Id3v1Tag *tag) {
+    if (tag == NULL) {
+        return GENRE_UNKNOWN;
+    }
     return tag->genre;
 }
 
@@ -699,6 +729,9 @@ Genre id3v1ReadGenre(const Id3v1Tag *tag) {
  * @return int - The track number value from the tag.
  */
 int id3v1ReadTrack(const Id3v1Tag *tag) {
+    if (tag == NULL) {
+        return 0;
+    }
     return tag->track;
 }
 
@@ -733,7 +766,10 @@ char *id3v1ToJSON(const Id3v1Tag *tag) {
         id3v1GenreFromTable(tag->genre));
 
     json = calloc(memCount + 1, sizeof(char));
-    (void) snprintf(json, memCount,
+    if (json == NULL) {
+        return NULL;
+    }
+    (void) snprintf(json, memCount + 1,
                     "{\"title\":\"%s\",\"artist\":\"%s\",\"album\":\"%s\",\"year\":%d,\"track\":%d,\"comment\":\"%s\",\"genreNumber\":%d,\"genre\":\"%s\"}",
                     (char *) tag->title,
                     (char *) tag->artist,
@@ -773,10 +809,19 @@ int id3v1WriteTagToFile(const char *filePath, const Id3v1Tag *tag) {
     byteStreamWrite(stream, (unsigned char *) tag->artist, ID3V1_FIELD_SIZE);
     byteStreamWrite(stream, (unsigned char *) tag->albumTitle, ID3V1_FIELD_SIZE);
 
-    //int to string
-    n = (int) log10(tag->year) + 1;
-    yearW = tag->year;
+    //int to string - handle edge cases for log10
+    if (tag->year <= 0) {
+        n = 1;
+        yearW = 0;
+    } else {
+        n = (int) log10(tag->year) + 1;
+        yearW = tag->year;
+    }
     tmp = calloc(n, sizeof(char));
+    if (tmp == NULL) {
+        byteStreamDestroy(stream);
+        return 0;
+    }
 
     for (int i = n - 1; i >= 0; --i, yearW /= 10) {
         tmp[i] = (char) ((yearW % 10) + '0');

--- a/src/id3v1/id3v1Parser.c
+++ b/src/id3v1/id3v1Parser.c
@@ -41,6 +41,9 @@ bool id3v1HasTag(const uint8_t *buffer) {
 Id3v1Tag *id3v1CreateTag(uint8_t *title, uint8_t *artist, uint8_t *albumTitle, int year, int track, uint8_t *comment,
                          Genre genre) {
     Id3v1Tag *tag = malloc(sizeof(Id3v1Tag));
+    if (tag == NULL) {
+        return NULL;
+    }
 
     //inits all members
     memset(tag, 0, sizeof(Id3v1Tag));

--- a/src/id3v2/id3v2TagIdentity.c
+++ b/src/id3v2/id3v2TagIdentity.c
@@ -807,6 +807,9 @@ char *id3v2ExtendedTagHeaderToJSON(const Id3v2ExtendedTagHeader *ext, uint8_t ve
 
     if (ext == NULL) {
         json = calloc(memCount, sizeof(char));
+        if (json == NULL) {
+            return NULL;
+        }
         memcpy(json, "{}\0", memCount);
         return json;
     }
@@ -820,8 +823,11 @@ char *id3v2ExtendedTagHeaderToJSON(const Id3v2ExtendedTagHeader *ext, uint8_t ve
                                  ext->crc);
 
             json = calloc(memCount + 1, sizeof(char)); // NOLINT(clang-analyzer-unix.Malloc)
+            if (json == NULL) {
+                return NULL;
+            }
 
-            (void) snprintf(json, memCount,
+            (void) snprintf(json, memCount + 1,
                             "{\"padding\":%"PRIu32",\"crc\":%"PRIu32"}",
                             ext->padding,
                             ext->crc);
@@ -839,8 +845,11 @@ char *id3v2ExtendedTagHeaderToJSON(const Id3v2ExtendedTagHeader *ext, uint8_t ve
                                  ext->restrictions);
 
             json = calloc(memCount + 1, sizeof(char)); // NOLINT(clang-analyzer-unix.Malloc)
+            if (json == NULL) {
+                return NULL;
+            }
 
-            (void) snprintf(json, memCount,
+            (void) snprintf(json, memCount + 1,
                             "{\"padding\":%"PRIu32",\"crc\":%"PRIu32
                             ",\"update\":%s,\"tagRestrictions\":%s,\"restrictions\":%d}",
                             ext->padding,


### PR DESCRIPTION
## Summary
- Fix compilation error caused by stray character in header file
- Add NULL safety checks to prevent null pointer dereferences
- Fix buffer overflow vulnerabilities in snprintf calls
- Add GENRE_UNKNOWN enum value for error handling

## Changes
- **id3v2Frame.h**: Remove stray 'x' character causing compilation failure
- **id3v1Types.h**: Add `GENRE_UNKNOWN = -1` for error cases
- **id3v1.c**: Add NULL parameter validation and allocation checks to read functions, fix log10 edge case for year=0
- **id3v1Parser.c**: Add NULL check after malloc in id3v1CreateTag
- **id3dev.c**: Add NULL checks and fix snprintf buffer size in id3ToJSON
- **id3v2TagIdentity.c**: Fix snprintf buffer size off-by-one errors